### PR TITLE
Handle no issue Ids in commit, and conventional commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npm run test
 npm run build
+git add dist/

--- a/dist/index.js
+++ b/dist/index.js
@@ -30108,7 +30108,7 @@ async function run() {
 
               // Then, remove conventional commit format [#12345] if it matches the nid
               // This prevents duplication like "#3554196: [#3554196] fix..." -> "fix..."
-              const conventionalCommitPattern = new RegExp(`\\[#${change.nid}\\]\\s*`, 'i');
+              const conventionalCommitPattern = new RegExp(`^\\[#${change.nid}\\]\\s*`, 'i');
               summaryWithoutId = summaryWithoutId.replace(conventionalCommitPattern, '');
 
               // Clean up any leading whitespace after removals

--- a/dist/index.js
+++ b/dist/index.js
@@ -30089,11 +30089,31 @@ async function run() {
 
             releaseNotesSection += `#### ${type}\n\n`;
             for (const change of typeGroup.changes) {
+              // Handle null nid (no issue ID in commit title)
+              if (change.nid === null) {
+                releaseNotesSection += `* ${change.summary}\n`;
+                continue;
+              }
+
               // Use nid from JSON data to create the issue ID link
               const issueId = `#${change.nid}`;
-              // Remove the issue ID prefix from summary (format: #12345: or #12345 by author:)
-              // Match: #12345 followed by optional " by author" and then ": " or just ": "
-              const summaryWithoutId = change.summary.replace(/^#[0-9]+(?:\s+by\s+[^:]+)?:\s*/, '');
+
+              // Remove the issue ID prefix from summary
+              // Handle traditional format: #12345: or #12345 by author:
+              // Also handle conventional commit format: [#12345] (remove if it matches the nid)
+              let summaryWithoutId = change.summary;
+
+              // First, remove traditional format: #12345: or #12345 by author:
+              summaryWithoutId = summaryWithoutId.replace(/^#[0-9]+(?:\s+by\s+[^:]+)?:\s*/, '');
+
+              // Then, remove conventional commit format [#12345] if it matches the nid
+              // This prevents duplication like "#3554196: [#3554196] fix..." -> "fix..."
+              const conventionalCommitPattern = new RegExp(`\\[#${change.nid}\\]\\s*`, 'i');
+              summaryWithoutId = summaryWithoutId.replace(conventionalCommitPattern, '');
+
+              // Clean up any leading whitespace after removals
+              summaryWithoutId = summaryWithoutId.trim();
+
               releaseNotesSection += `* [${issueId}](${change.link})${summaryWithoutId ? ': ' + summaryWithoutId : ''}\n`;
             }
             releaseNotesSection += '\n';

--- a/src/index.js
+++ b/src/index.js
@@ -162,11 +162,31 @@ async function run() {
 
             releaseNotesSection += `#### ${type}\n\n`;
             for (const change of typeGroup.changes) {
+              // Handle null nid (no issue ID in commit title)
+              if (change.nid === null) {
+                releaseNotesSection += `* ${change.summary}\n`;
+                continue;
+              }
+
               // Use nid from JSON data to create the issue ID link
               const issueId = `#${change.nid}`;
-              // Remove the issue ID prefix from summary (format: #12345: or #12345 by author:)
-              // Match: #12345 followed by optional " by author" and then ": " or just ": "
-              const summaryWithoutId = change.summary.replace(/^#[0-9]+(?:\s+by\s+[^:]+)?:\s*/, '');
+
+              // Remove the issue ID prefix from summary
+              // Handle traditional format: #12345: or #12345 by author:
+              // Also handle conventional commit format: [#12345] (remove if it matches the nid)
+              let summaryWithoutId = change.summary;
+
+              // First, remove traditional format: #12345: or #12345 by author:
+              summaryWithoutId = summaryWithoutId.replace(/^#[0-9]+(?:\s+by\s+[^:]+)?:\s*/, '');
+
+              // Then, remove conventional commit format [#12345] if it matches the nid
+              // This prevents duplication like "#3554196: [#3554196] fix..." -> "fix..."
+              const conventionalCommitPattern = new RegExp(`\\[#${change.nid}\\]\\s*`, 'i');
+              summaryWithoutId = summaryWithoutId.replace(conventionalCommitPattern, '');
+
+              // Clean up any leading whitespace after removals
+              summaryWithoutId = summaryWithoutId.trim();
+
               releaseNotesSection += `* [${issueId}](${change.link})${summaryWithoutId ? ': ' + summaryWithoutId : ''}\n`;
             }
             releaseNotesSection += '\n';

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ async function run() {
 
               // Then, remove conventional commit format [#12345] if it matches the nid
               // This prevents duplication like "#3554196: [#3554196] fix..." -> "fix..."
-              const conventionalCommitPattern = new RegExp(`\\[#${change.nid}\\]\\s*`, 'i');
+              const conventionalCommitPattern = new RegExp(`^\\[#${change.nid}\\]\\s*`, 'i');
               summaryWithoutId = summaryWithoutId.replace(conventionalCommitPattern, '');
 
               // Clean up any leading whitespace after removals


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves release notes formatting to handle null nids and remove duplicate issue IDs; adds targeted tests and updates pre-commit to add dist.
> 
> - **Release notes generation (`src/index.js`)**:
>   - Handle `change.nid === null` by outputting unlinked summaries.
>   - Strip issue ID prefixes from summaries in both traditional (`#12345:` / `by author`) and conventional (`[#12345]`) formats based on `nid`, then trim.
> - **Tests (`src/index.test.js`)**:
>   - Add cases for null `nid` (no link) and conventional commit duplication removal.
>   - Verify correct linking, summary cleanup, and absence of empty links.
> - **Tooling**:
>   - Update `.husky/pre-commit` to `git add dist/`.
> - **Build**:
>   - Regenerate `dist/index.js` with the above logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b07246d9fb7aa5567377b629f72626c0c152192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->